### PR TITLE
Add support for MSVN

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
     "cSpell.words": [
         "handshook",
-        "Msvn",
+        "msvn",
         "stepkic"
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
     "cSpell.words": [
         "handshook",
+        "Msvn",
         "stepkic"
     ]
 }

--- a/src/main/engines/api.ts
+++ b/src/main/engines/api.ts
@@ -2,14 +2,14 @@
 import { ipcMain } from "electron";
 import { Request } from "../../shared/messaging/engines/request";
 import { Response } from "../../shared/messaging/engines/response";
-import { EngineInfo, ProcessInfo } from "../../shared/model";
+import { EngineInfo, Msvn, ProcessInfo } from "../../shared/model";
 import { spawn } from "child_process";
 import { createInterface } from "node:readline";
 import { Process } from "./process";
 import { sha1 } from "object-hash";
 import { Store } from "../store";
 
-export const api = (store: Store) => {
+export const api = (store: Store, msvn: Msvn) => {
   const _delete = (id: string) => {
     const engines = store.get("engines", {});
     delete engines[id];
@@ -29,7 +29,7 @@ export const api = (store: Store) => {
       console.log(process, line);
       Process.match({
         opened: () => {
-          if (line.trim() !== "st3p version 2 ok") {
+          if (line.trim() !== Msvn.expectation(msvn)) {
             next(process);
             return;
           }
@@ -73,7 +73,7 @@ export const api = (store: Store) => {
       })(process);
     };
     rl.on("line", matcher);
-    stdin.write("st3p version 2\n");
+    stdin.write(`${Msvn.handshake(msvn)}\n`);
   };
   ipcMain.on("engines", ({ reply }, request: Request) => {
     Request.match({

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -6,6 +6,7 @@ import { coordinator } from "./coordinator";
 import { api } from "./engines/api";
 import fixPath from "fix-path";
 import { store } from "./store";
+import { msvn } from "./msvn";
 
 // Handle creating/removing shortcuts on Windows when installing/uninstalling.
 if (require("electron-squirrel-startup")) {
@@ -76,12 +77,14 @@ app.on("ready", () => {
   const window = createWindow();
   const _store = store();
   createEnginesWindow();
+  const _msvn = msvn(app);
   const receiver = coordinator({
     send: (r) => window.webContents.send("main", r),
     store: _store,
+    msvn: _msvn,
   });
   ipcMain.on("main", (_, arg: Sendable) => receiver(arg));
-  api(_store);
+  api(_store, _msvn);
 });
 
 // Quit when all windows are closed, except on macOS. There, it's common

--- a/src/main/msvn.ts
+++ b/src/main/msvn.ts
@@ -1,0 +1,20 @@
+import { App, ipcMain } from "electron";
+import { MsvnRequested, MsvnUpdated } from "../shared/messaging/msvn";
+import { Msvn } from "../shared/model";
+
+const DEFAULT_MSVN = 2;
+
+export const msvn = (app: App) => {
+  const value = Number(app.commandLine.getSwitchValue("msvn"));
+  const msvn: Msvn = {
+    tag: "msvn",
+    args: [Number.isSafeInteger(value) && value > 0 ? value : DEFAULT_MSVN],
+  };
+
+  ipcMain.on("msvn", ({ reply }, request: MsvnRequested) => {
+    console.log(request);
+    reply("msvn", MsvnUpdated(msvn));
+  });
+
+  return msvn;
+}

--- a/src/renderer/engines/app.tsx
+++ b/src/renderer/engines/app.tsx
@@ -4,16 +4,19 @@ import { AddEngine } from "./add-engine";
 import { useEngines } from "./use-engines";
 import "./global.scss";
 import { CreateGame } from "./create-game";
+import { useMsvn } from "../shared/use-msvn";
 
 export const App: FC = () => {
   const { engines, onAdd, onPlay, onDelete } = useEngines();
   const [addRequested, setAddRequested] = useState(false);
   const [createRequested, setCreateRequested] = useState(false);
+  const msvn = useMsvn();
 
   return (
     <>
       <AddEngine open={addRequested} setOpen={setAddRequested} onAdd={onAdd} />
       <CreateGame
+        msvn={msvn}
         engines={engines}
         open={createRequested}
         setOpen={setCreateRequested}

--- a/src/renderer/engines/create-game.tsx
+++ b/src/renderer/engines/create-game.tsx
@@ -8,7 +8,7 @@ import {
   Column,
   Form,
 } from "@carbon/react";
-import { EngineInfo } from "../../shared/model";
+import { EngineInfo, Msvn } from "../../shared/model";
 import ReactDOM from "react-dom";
 import { Identifiable } from "./identifiable.type";
 import { NewGameArgs } from "./new-game-args";
@@ -16,13 +16,20 @@ import { NewGameArgs } from "./new-game-args";
 type IdentifiableEngine = Identifiable<EngineInfo>;
 
 type Props = {
+  msvn: Msvn;
   engines: IdentifiableEngine[];
   open: boolean;
   setOpen: (open: boolean) => void;
   onPlay: (args: NewGameArgs) => void;
 };
 
-export const CreateGame: FC<Props> = ({ engines, open, setOpen, onPlay }) => {
+export const CreateGame: FC<Props> = ({
+  engines,
+  msvn,
+  open,
+  setOpen,
+  onPlay,
+}) => {
   const map = engines.reduce(
     (map, engine) => map.set(engine.id, engine),
     new Map<string, IdentifiableEngine>()
@@ -124,14 +131,16 @@ export const CreateGame: FC<Props> = ({ engines, open, setOpen, onPlay }) => {
           onChange={onSizeChange}
           invalidText="Invalid size"
         />
-        <Slider
-          labelText="Win Length"
-          value={winLength}
-          min={2}
-          max={size}
-          onChange={({ value }) => setWinLength(value)}
-          invalidText="Invalid win length"
-        />
+        {Msvn.above(2)(() => <></>)(() => (
+          <Slider
+            labelText="Win Length"
+            value={winLength}
+            min={2}
+            max={size}
+            onChange={({ value }) => setWinLength(value)}
+            invalidText="Invalid win length"
+          />
+        ))(msvn)}
       </Form>
     </Modal>,
     document.body

--- a/src/renderer/shared/use-msvn.ts
+++ b/src/renderer/shared/use-msvn.ts
@@ -1,0 +1,22 @@
+import { useEffect, useState } from "react";
+import { Msvn } from "../../shared/model";
+import { MsvnUpdated, MsvnRequested } from "../../shared/messaging/msvn";
+
+export const useMsvn = () => {
+  const [msvn, setMsvn] = useState(Msvn.default());
+
+  useEffect(
+    () =>
+      window.electron.ipcRenderer.on("msvn", (_, response: MsvnUpdated) => {
+        setMsvn(response.args[0]);
+      }),
+    [setMsvn]
+  );
+
+  useEffect(
+    () => window.electron.ipcRenderer.send("msvn", MsvnRequested()),
+    []
+  );
+
+  return msvn;
+};

--- a/src/shared/messaging/msvn.ts
+++ b/src/shared/messaging/msvn.ts
@@ -1,0 +1,16 @@
+import { Msvn } from "../model";
+import { Tagged } from "../tagged";
+
+export type MsvnRequested = Tagged<"msvn-requested", []>;
+
+export const MsvnRequested = (): MsvnRequested => ({
+  tag: "msvn-requested",
+  args: [],
+});
+
+export type MsvnUpdated = Tagged<"msvn-updated", [Msvn]>;
+
+export const MsvnUpdated = (msvn: Msvn): MsvnUpdated => ({
+  tag: "msvn-updated",
+  args: [msvn],
+});

--- a/src/shared/model/index.ts
+++ b/src/shared/model/index.ts
@@ -13,3 +13,4 @@ export * from "./timestamp";
 export * from "./user";
 export * from "./result";
 export * from "./engine-identification";
+export * from "./msvn";

--- a/src/shared/model/msvn.ts
+++ b/src/shared/model/msvn.ts
@@ -1,0 +1,16 @@
+import { Tagged } from "../tagged";
+
+export type Msvn = Tagged<"msvn", [number]>;
+
+export const Msvn = {
+  default: (): Msvn => ({ tag: "msvn", args: [1] }),
+  handshake: ({ args: [msvn] }: Msvn): string =>
+    ["st3p", "version", msvn.toString()].join(" "),
+  expectation: (msvn: Msvn): string => [Msvn.handshake(msvn), "ok"].join(" "),
+  above:
+    (min: number) =>
+    <T>(no: () => T) =>
+    (yes: () => T) =>
+    ({ args: [msvn] }: Msvn): T =>
+      msvn >= min ? yes() : no(),
+};


### PR DESCRIPTION
We can now control the MSVN by passing a command line arg called `msvn`.

The default MSVN is the highest (2 as of now) however it can be changed.

For example,

```sh
yarn start -- -- --msvn=1
```

will set it to 1

The two sets of `--` are required, one for `yarn` and another for `electron-forge` to pass through the following CLI args.